### PR TITLE
fix(fullbright):Bleasdale Farmhouse dark furniture

### DIFF
--- a/PhasmoCheatV Recode.vcxproj
+++ b/PhasmoCheatV Recode.vcxproj
@@ -539,6 +539,7 @@
     <ClInclude Include="main\sdk\Transform.h" />
     <ClInclude Include="main\sdk\Vector2.h" />
     <ClInclude Include="main\sdk\Vector3.h" />
+    <ClInclude Include="main\sdk\Vector4.h" />
     <ClInclude Include="main\sdk\Voice.h" />
     <ClInclude Include="main\sdk\VoodooDollPin.h" />
     <ClInclude Include="main\sdk\WeatherProfile.h" />

--- a/PhasmoCheatV Recode.vcxproj.filters
+++ b/PhasmoCheatV Recode.vcxproj.filters
@@ -1,403 +1,1174 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="dllmain.cpp" />
-    <ClCompile Include="libs\il2cpp\il2cpp.cpp" />
-    <ClCompile Include="libs\imgui\imgui.cpp" />
-    <ClCompile Include="libs\imgui\imgui_demo.cpp" />
-    <ClCompile Include="libs\imgui\imgui_draw.cpp" />
-    <ClCompile Include="libs\imgui\imgui_impl_dx11.cpp" />
-    <ClCompile Include="libs\imgui\imgui_impl_win32.cpp" />
-    <ClCompile Include="libs\imgui\imgui_tables.cpp" />
-    <ClCompile Include="libs\imgui\imgui_widgets.cpp" />
-    <ClCompile Include="libs\miniz\miniz.c" />
-    <ClCompile Include="libs\z85\z85.c" />
-    <ClCompile Include="libs\z85\z85_impl.cpp" />
-    <ClCompile Include="loader\entry.cpp" />
-    <ClCompile Include="loader\proxy.cpp" />
-    <ClCompile Include="main\config\config.cpp" />
-    <ClCompile Include="main\config\configs_manager.cpp" />
-    <ClCompile Include="main\config\LanguageManager.cpp" />
-    <ClCompile Include="main\diagnostics\diagnostics.cpp" />
-    <ClCompile Include="main\discordrpc\discordrpc.cpp" />
-    <ClCompile Include="main\features\feats\actmonik\actmonik.cpp" />
-    <ClCompile Include="main\features\feats\alwaysbloodmoon\alwaysbloodmoon.cpp" />
-    <ClCompile Include="main\features\feats\antikick\antikick.cpp" />
-    <ClCompile Include="main\features\feats\audiomod\audiomod.cpp" />
-    <ClCompile Include="main\features\feats\autogame\autogame.cpp" />
-    <ClCompile Include="main\features\feats\autopickupbone\autopickupbone.cpp" />
-    <ClCompile Include="main\features\feats\awesp\awesp.cpp" />
-    <ClCompile Include="main\features\feats\cosmeticsunlocker\cosmeticunlocker.cpp" />
-    <ClCompile Include="main\features\feats\crosshairmod\crosshairmod.cpp" />
-    <ClCompile Include="main\features\feats\customlooklimits\customlooklimits.cpp" />
-    <ClCompile Include="main\features\feats\curseditemscontroll\curseditemscontroll.cpp" />
-    <ClCompile Include="main\features\feats\custname\customname.cpp" />
-    <ClCompile Include="main\features\feats\custspeed\customspeed.cpp" />
-    <ClCompile Include="main\features\feats\gamespeed\gamespeed.cpp" />
-    <ClCompile Include="main\features\feats\spinbot\spinbot.cpp" />
-    <ClCompile Include="main\features\feats\ghostspin\ghostspin.cpp" />
-    <ClCompile Include="main\features\feats\ghosthandstand\ghosthandstand.cpp" />
-    <ClCompile Include="main\features\feats\diffmod\difficultymodifier.cpp" />
-    <ClCompile Include="main\features\feats\doormod\doormodifier.cpp" />
-    <ClCompile Include="main\features\feats\edvesp\edvesp.cpp" />
-    <ClCompile Include="main\features\feats\exitvanone\exitvanone.cpp" />
-    <ClCompile Include="main\features\feats\fastthermometer\fastthermometer.cpp" />
-    <ClCompile Include="main\features\feats\flashlightmod\flashlightmod.cpp" />
-    <ClCompile Include="main\features\feats\fontchanger\fontchanger.cpp" />
-    <ClCompile Include="main\features\feats\forcestart\forcestart.cpp" />
-    <ClCompile Include="main\features\feats\foveditor\foveditor.cpp" />
-    <ClCompile Include="main\features\feats\fullbright\fullbright.cpp" />
-    <ClCompile Include="main\features\feats\fuseesp\fuseesp.cpp" />
-    <ClCompile Include="main\features\feats\fusemod\fusemod.cpp" />
-    <ClCompile Include="main\features\feats\ghostdesign\ghostdesign.cpp" />
-    <ClCompile Include="main\features\feats\ghostesp\ghostesp.cpp" />
-    <ClCompile Include="main\features\feats\ghostinter\ghostinter.cpp" />
-    <ClCompile Include="main\features\feats\ghostmod\ghostmodifier.cpp" />
-    <ClCompile Include="main\features\feats\ghostpanel\ghostpanel.cpp" />
-    <ClCompile Include="main\features\feats\godmode\godmode.cpp" />
-    <ClCompile Include="main\features\feats\grabkey\grabkey.cpp" />
-    <ClCompile Include="main\features\feats\infstamina\infinitystamina.cpp" />
-    <ClCompile Include="main\features\feats\jackalopeesp\jackalopeesp.cpp" />
-    <ClCompile Include="main\features\feats\journalmod\journalmod.cpp" />
-    <ClCompile Include="main\features\feats\musicpanel\musicpanel.cpp" />
-    <ClCompile Include="main\features\feats\photomod\photomod.cpp" />
-    <ClCompile Include="main\features\feats\showmic\showmic.cpp" />
-    <ClCompile Include="main\features\feats\skiplayeranim\skiplayeranim.cpp" />
-    <ClCompile Include="main\features\feats\spiritboxalw\spiritboxalw.cpp" />
-    <ClCompile Include="main\features\feats\vanbuttonmod\vanbuttonmod.cpp" />
-    <ClCompile Include="main\features\feats\mapmod\mapmodifier.cpp" />
-    <ClCompile Include="main\features\feats\noclip\noclip.cpp" />
-    <ClCompile Include="main\features\feats\noendgame\noendgame.cpp" />
-    <ClCompile Include="main\features\feats\notifyinfo\notifyinfo.cpp" />
-    <ClCompile Include="main\features\feats\pickup\pickup.cpp" />
-    <ClCompile Include="main\features\feats\playeresp\playeresp.cpp" />
-    <ClCompile Include="main\features\feats\playermod\playermodifier.cpp" />
-    <ClCompile Include="main\features\feats\playerpanel\playerpanel.cpp" />
-    <ClCompile Include="main\features\feats\potatoeesp\potatoeesp.cpp" />
-    <ClCompile Include="main\features\feats\rewardmod\rewardmodifier.cpp" />
-    <ClCompile Include="main\features\feats\saltmod\saltmodifier.cpp" />
-    <ClCompile Include="main\features\feats\shopmod\shopmodifier.cpp" />
-    <ClCompile Include="main\features\feats\statspanel\statspanel.cpp" />
-    <ClCompile Include="main\features\feats\teleport\teleport.cpp" />
-    <ClCompile Include="main\features\feats\temperaturepanel\temperaturepanel.cpp" />
-    <ClCompile Include="main\features\feats\tests\test.cpp" />
-    <ClCompile Include="main\features\feats\waterka\watermark.cpp" />
-    <ClCompile Include="main\features\feats\worldmodulation\worldmodulation.cpp" />
-    <ClCompile Include="main\features\feature.cpp" />
-    <ClCompile Include="main\hooks\Application_CallLogCallback.cpp" />
-    <ClCompile Include="main\hooks\AWDoll_Awake.cpp" />
-    <ClCompile Include="main\hooks\CosmeticsUnlocker.cpp" />
-    <ClCompile Include="main\hooks\CursedItemsController_Awake.cpp" />
-    <ClCompile Include="main\hooks\DNAEvidence_GrabbedNetworked.cpp" />
-    <ClCompile Include="main\hooks\DNAEvidence_Start.cpp" />
-    <ClCompile Include="main\hooks\EMFData_Start.cpp" />
-    <ClCompile Include="main\hooks\EMFData_UpdateNightMareGraph.cpp" />
-    <ClCompile Include="main\hooks\EvidenceController_Start.cpp" />
-    <ClCompile Include="main\hooks\EVPRecorder_CanAnswer.cpp" />
-    <ClCompile Include="main\hooks\ExitLevel_Exit.cpp" />
-    <ClCompile Include="main\hooks\ExitLevel_ThereAreAlivePlayersOutsideTheTruck.cpp" />
-    <ClCompile Include="main\hooks\FallTeleportBox_OnTriggerEnter.cpp" />
-    <ClCompile Include="main\hooks\FirstPersonController_Update.cpp" />
-    <ClCompile Include="main\hooks\GameController_Awake.cpp" />
-    <ClCompile Include="main\hooks\GameController_Exit.cpp" />
-    <ClCompile Include="main\hooks\GameController_PlayerDied.cpp" />
-    <ClCompile Include="main\hooks\GhostAI_Hunting.cpp" />
-    <ClCompile Include="main\hooks\GhostAI_Start.cpp" />
-    <ClCompile Include="main\hooks\GhostAI_Update.cpp" />
-    <ClCompile Include="main\hooks\GhostInfo_SyncEvidence.cpp" />
-    <ClCompile Include="main\hooks\GhostInfo_SyncValuesNetworked.cpp" />
-    <ClCompile Include="main\hooks\HandCamera_MoveNext.cpp" />
-    <ClCompile Include="main\hooks\Jackalope_Awake.cpp" />
-    <ClCompile Include="main\hooks\Key_GrabbedKey.cpp" />
-    <ClCompile Include="main\hooks\Key_Start.cpp" />
-    <ClCompile Include="main\hooks\LevelController_Start.cpp" />
-    <ClCompile Include="main\hooks\LevelSelectionManager_Start.cpp" />
-    <ClCompile Include="main\hooks\LevelValues_GetInvestigationBonusReward.cpp" />
-    <ClCompile Include="main\hooks\LevelValues_IsPerfectGame.cpp" />
-    <ClCompile Include="main\hooks\LiftButton_AttemptUse.cpp" />
-    <ClCompile Include="main\hooks\LiftButton_Update.cpp" />
-    <ClCompile Include="main\hooks\LightningController_Start.cpp" />
-    <ClCompile Include="main\hooks\LightSwitch_Start.cpp" />
-    <ClCompile Include="main\hooks\PhotonView_RPC.cpp" />
-    <ClCompile Include="main\hooks\Player_Start.cpp" />
-    <ClCompile Include="main\hooks\Player_StartDeathAnimation.cpp" />
-    <ClCompile Include="main\hooks\RandomWeather_Start.cpp" />
-    <ClCompile Include="main\hooks\RewardManager_Awake.cpp" />
-    <ClCompile Include="main\hooks\SceneManagement_Internal_SceneLoaded.cpp" />
-    <ClCompile Include="main\hooks\ScriptableRenderContext_Submit.cpp" />
-    <ClCompile Include="main\hooks\ServerManager_LoadScene.cpp" />
-    <ClCompile Include="main\hooks\TarotCards_BreakItem.cpp" />
-    <ClCompile Include="main\hooks\TarotCards_GrabCard.cpp" />
-    <ClCompile Include="main\hooks\MediaValues_GetRewardAmount.cpp" />
-    <ClCompile Include="main\hooks\ObjectiveManager_Update.cpp" />
-    <ClCompile Include="main\hooks\PauseMenuController_Leave.cpp" />
-    <ClCompile Include="main\hooks\PhotonObjectInteract_Start.cpp" />
-    <ClCompile Include="main\hooks\PlayerStamina_Update.cpp" />
-    <ClCompile Include="main\hooks\Present.cpp" />
-    <ClCompile Include="main\hooks\SaltShaker_Update.cpp" />
-    <ClCompile Include="main\hooks\SaltSpot_SyncSalt.cpp" />
-    <ClCompile Include="main\hooks\ServerManager_KickPlayerNetworked.cpp" />
-    <ClCompile Include="main\hooks\ServerManager_Ready.cpp" />
-    <ClCompile Include="main\hooks\TarotCard_SetCard.cpp" />
-    <ClCompile Include="main\hooks\Thermometer_HoldUse.cpp" />
-    <ClCompile Include="main\hooks\VoodooDollPin_Use.cpp" />
-    <ClCompile Include="main\hooks\WndProc.cpp" />
-    <ClCompile Include="main\hooks\hooking.cpp" />
-    <ClCompile Include="main\hooks\MapController_Start.cpp" />
-    <ClCompile Include="main\logging\logger.cpp" />
-    <ClCompile Include="main\mem\memory.cpp" />
-    <ClCompile Include="main\menu\effects\custom_background.cpp" />
-    <ClCompile Include="main\menu\menu.cpp" />
-    <ClCompile Include="main\menu\renderer.cpp" />
-    <ClCompile Include="main\utils\utils.cpp" />
-    <ClCompile Include="main\features\feats\staminapanel\staminapanel.cpp" />
+    <Filter Include="Исходные файлы">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Файлы заголовков">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Файлы ресурсов">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="detours">
+      <UniqueIdentifier>{b5b9db23-bb16-42da-9999-7edcdd8a0ac6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="imgui">
+      <UniqueIdentifier>{97023ca2-4130-48d5-a386-abe98a1d37ec}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Il2cpp">
+      <UniqueIdentifier>{bc5ab0cc-28fa-4e80-8ecf-91b57c6dfaca}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="sdk">
+      <UniqueIdentifier>{1f53e4d2-b77f-4d8a-ac4e-12d291ce014f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="hooks">
+      <UniqueIdentifier>{4507e7b9-9587-4c96-bf56-87a98fd2a068}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="logger">
+      <UniqueIdentifier>{3aaee8ac-f36e-4f80-8a2a-1902336f23c2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="menu">
+      <UniqueIdentifier>{3047d702-ce57-4222-90f9-8823e99ad6f6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="utils">
+      <UniqueIdentifier>{16714487-2458-4919-8514-66567f53af4b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="features">
+      <UniqueIdentifier>{72e9687e-963a-40e8-83f5-d4e41d5597ab}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="features\feats">
+      <UniqueIdentifier>{d19d3a8f-dbb5-435e-85d2-6c9dbcb7f124}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="configs">
+      <UniqueIdentifier>{af337e08-b120-428b-8087-a4c7e9beb5be}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="fonts">
+      <UniqueIdentifier>{c78ec3a6-4cc9-44e5-a7ef-76dbc7d85d8b}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Globals.h" />
-    <ClInclude Include="Includes.h" />
-    <ClInclude Include="inGame.h" />
-    <ClInclude Include="libs\detours\include\detours.h" />
-    <ClInclude Include="libs\detours\include\detver.h" />
-    <ClInclude Include="libs\detours\include\syelog.h" />
-    <ClInclude Include="libs\il2cpp\il2cpp.h" />
-    <ClInclude Include="libs\imgui\imconfig.h" />
-    <ClInclude Include="libs\imgui\imgui.h" />
-    <ClInclude Include="libs\imgui\imgui_impl_dx11.h" />
-    <ClInclude Include="libs\imgui\imgui_impl_win32.h" />
-    <ClInclude Include="libs\imgui\imgui_internal.h" />
-    <ClInclude Include="libs\imgui\imstb_rectpack.h" />
-    <ClInclude Include="libs\imgui\imstb_textedit.h" />
-    <ClInclude Include="libs\imgui\imstb_truetype.h" />
-    <ClInclude Include="libs\miniz\miniz.h" />
-    <ClInclude Include="libs\z85\z85.h" />
-    <ClInclude Include="libs\z85\z85.hpp" />
-    <ClInclude Include="loader\entry.h" />
-    <ClInclude Include="loader\proxy.h" />
-    <ClInclude Include="main\config\BindSystem.h" />
-    <ClInclude Include="main\config\config.h" />
-    <ClInclude Include="main\config\configs_manager.h" />
-    <ClInclude Include="main\config\LanguageManager.h" />
-    <ClInclude Include="main\config\Translations.h" />
-    <ClInclude Include="main\diagnostics\diagnostics.h" />
-    <ClInclude Include="main\discordrpc\discordrpc.h" />
-    <ClInclude Include="main\features\feats\actmonik\actmonik.h" />
-    <ClInclude Include="main\features\feats\360camera\camera360.h" />
-    <ClInclude Include="main\features\feats\alwaysbloodmoon\alwaysbloodmoon.h" />
-    <ClInclude Include="main\features\feats\antikick\antikick.h" />
-    <ClInclude Include="main\features\feats\audiomod\audiomod.h" />
-    <ClInclude Include="main\features\feats\autogame\autogame.h" />
-    <ClInclude Include="main\features\feats\autopickupbone\autopickupbone.h" />
-    <ClInclude Include="main\features\feats\awesp\awesp.h" />
-    <ClInclude Include="main\features\feats\cosmeticsunlocker\cosmeticunlocker.h" />
-    <ClInclude Include="main\features\feats\crosshairmod\crosshairmod.h" />
-    <ClInclude Include="main\features\feats\customlooklimits\customlooklimits.h" />
-    <ClInclude Include="main\features\feats\curseditemscontroll\curseditemscontroll.h" />
-    <ClInclude Include="main\features\feats\custname\customname.h" />
-    <ClInclude Include="main\features\feats\custspeed\customspeed.h" />
-    <ClInclude Include="main\features\feats\gamespeed\gamespeed.h" />
-    <ClInclude Include="main\features\feats\spinbot\spinbot.h" />
-    <ClInclude Include="main\features\feats\ghostspin\ghostspin.h" />
-    <ClInclude Include="main\features\feats\ghosthandstand\ghosthandstand.h" />
-    <ClInclude Include="main\features\feats\diffmod\difficultymodifier.h" />
-    <ClInclude Include="main\features\feats\doormod\doormodifier.h" />
-    <ClInclude Include="main\features\feats\edvesp\edvesp.h" />
-    <ClInclude Include="main\features\feats\exitvanone\exitvanone.h" />
-    <ClInclude Include="main\features\feats\fastthermometer\fastthermometer.h" />
-    <ClInclude Include="main\features\feats\flashlightmod\flashlightmod.h" />
-    <ClInclude Include="main\features\feats\fontchanger\fontchanger.h" />
-    <ClInclude Include="main\features\feats\forcestart\forcestart.h" />
-    <ClInclude Include="main\features\feats\foveditor\foveditor.h" />
-    <ClInclude Include="main\features\feats\fullbright\fullbright.h" />
-    <ClInclude Include="main\features\feats\fuseesp\fuseesp.h" />
-    <ClInclude Include="main\features\feats\fusemod\fusemod.h" />
-    <ClInclude Include="main\features\feats\ghostdesign\ghostdesign.h" />
-    <ClInclude Include="main\features\feats\ghostesp\ghostesp.h" />
-    <ClInclude Include="main\features\feats\ghostinter\ghostinter.h" />
-    <ClInclude Include="main\features\feats\ghostmod\ghostmodifier.h" />
-    <ClInclude Include="main\features\feats\ghostpanel\ghostpanel.h" />
-    <ClInclude Include="main\features\feats\godmode\godmode.h" />
-    <ClInclude Include="main\features\feats\grabkey\grabkey.h" />
-    <ClInclude Include="main\features\feats\infstamina\infinitystamina.h" />
-    <ClInclude Include="main\features\feats\jackalopeesp\jackalopeesp.h" />
-    <ClInclude Include="main\features\feats\journalmod\journalmod.h" />
-    <ClInclude Include="main\features\feats\musicpanel\musicpanel.h" />
-    <ClInclude Include="main\features\feats\photomod\photomod.h" />
-    <ClInclude Include="main\features\feats\showmic\showmic.h" />
-    <ClInclude Include="main\features\feats\skiplayeranim\skiplayeranim.h" />
-    <ClInclude Include="main\features\feats\spiritboxalw\spiritboxalw.h" />
-    <ClInclude Include="main\features\feats\vanbuttonmod\vanbuttonmod.h" />
-    <ClInclude Include="main\features\feats\mapmod\mapmodifier.h" />
-    <ClInclude Include="main\features\feats\noclip\noclip.h" />
-    <ClInclude Include="main\features\feats\noendgame\noendgame.h" />
-    <ClInclude Include="main\features\feats\notifyinfo\notifyinfo.h" />
-    <ClInclude Include="main\features\feats\pickup\pickup.h" />
-    <ClInclude Include="main\features\feats\playeresp\playeresp.h" />
-    <ClInclude Include="main\features\feats\playermod\playermodifier.h" />
-    <ClInclude Include="main\features\feats\playerpanel\playerpanel.h" />
-    <ClInclude Include="main\features\feats\potatoeesp\potatoeesp.h" />
-    <ClInclude Include="main\features\feats\rewardmod\rewardmodifier.h" />
-    <ClInclude Include="main\features\feats\saltmod\saltmodifier.h" />
-    <ClInclude Include="main\features\feats\shopmod\shopmodifier.h" />
-    <ClInclude Include="main\features\feats\statspanel\statspanel.h" />
-    <ClInclude Include="main\features\feats\teleport\teleport.h" />
-    <ClInclude Include="main\features\feats\temperaturepanel\temperaturepanel.h" />
-    <ClInclude Include="main\features\feats\tests\test.h" />
-    <ClInclude Include="main\features\feats\waterka\watermark.h" />
-    <ClInclude Include="main\features\feats\worldmodulation\worldmodulation.h" />
-    <ClInclude Include="main\features\feature.h" />
-    <ClInclude Include="main\features\features_includes.h" />
-    <ClInclude Include="main\features\settings.h" />
-    <ClInclude Include="main\hooks\hooking.h" />
-    <ClInclude Include="main\hooks\Hooks.h" />
-    <ClInclude Include="main\logging\logger.h" />
-    <ClInclude Include="main\mem\memory.h" />
-    <ClInclude Include="main\menu\effects\custom_background.h" />
-    <ClInclude Include="main\menu\effects\directx_blur.h" />
-    <ClInclude Include="main\menu\effects\fireflies.h" />
-    <ClInclude Include="main\menu\effects\petals.h" />
-    <ClInclude Include="main\menu\effects\stars.h" />
-    <ClInclude Include="main\menu\menu.h" />
-    <ClInclude Include="main\menu\effects\pshader.h" />
-    <ClInclude Include="main\menu\effects\rain.h" />
-    <ClInclude Include="main\menu\renderer.h" />
-    <ClInclude Include="main\menu\styles.h" />
-    <ClInclude Include="main\sdk\Animator.h" />
-    <ClInclude Include="main\sdk\Application.h" />
-    <ClInclude Include="main\sdk\AudioSource.h" />
-    <ClInclude Include="main\sdk\AWDoll.h" />
-    <ClInclude Include="main\sdk\AzureEffectsController.h" />
-    <ClInclude Include="main\sdk\Button.h" />
-    <ClInclude Include="main\sdk\Camera.h" />
-    <ClInclude Include="main\sdk\Candle.h" />
-    <ClInclude Include="main\sdk\Collider.h" />
-    <ClInclude Include="main\sdk\Color.h" />
-    <ClInclude Include="main\sdk\Component.h" />
-    <ClInclude Include="main\sdk\Contract.h" />
-    <ClInclude Include="main\sdk\CosmeticUnlocker.h" />
-    <ClInclude Include="main\sdk\CursedItem.h" />
-    <ClInclude Include="main\sdk\CursedItemsController.h" />
-    <ClInclude Include="main\sdk\Cursor.h" />
-    <ClInclude Include="main\sdk\Difficulty.h" />
-    <ClInclude Include="main\sdk\DNAEvidence.h" />
-    <ClInclude Include="main\sdk\Door.h" />
-    <ClInclude Include="main\sdk\EMF.h" />
-    <ClInclude Include="main\sdk\EMFData.h" />
-    <ClInclude Include="main\sdk\Equipment.h" />
-    <ClInclude Include="main\sdk\Evidence.h" />
-    <ClInclude Include="main\sdk\EvidenceController.h" />
-    <ClInclude Include="main\sdk\EVPRecorder.h" />
-    <ClInclude Include="main\sdk\ExitLevel.h" />
-    <ClInclude Include="main\sdk\FallTeleportBox.h" />
-    <ClInclude Include="main\sdk\FirstPersonController.h" />
-    <ClInclude Include="main\sdk\Font.h" />
-    <ClInclude Include="main\sdk\FuseBox.h" />
-    <ClInclude Include="main\sdk\GameController.h" />
-    <ClInclude Include="main\sdk\GameObject.h" />
-    <ClInclude Include="main\sdk\GhostActivity.h" />
-    <ClInclude Include="main\sdk\GhostAI.h" />
-    <ClInclude Include="main\sdk\GhostButton.h" />
-    <ClInclude Include="main\sdk\GhostEvidence.h" />
-    <ClInclude Include="main\sdk\GhostInfo.h" />
-    <ClInclude Include="main\sdk\GhostModel.h" />
-    <ClInclude Include="main\sdk\GhostTraits.h" />
-    <ClInclude Include="main\sdk\Graphic.h" />
-    <ClInclude Include="main\sdk\HandCamera.h" />
-    <ClInclude Include="main\sdk\ItemInfo.h" />
-    <ClInclude Include="main\sdk\Jackalope.h" />
-    <ClInclude Include="main\sdk\JournalController.h" />
-    <ClInclude Include="main\sdk\JournalMedia.h" />
-    <ClInclude Include="main\sdk\Journal_PhotoPage.h" />
-    <ClInclude Include="main\sdk\Key.h" />
-    <ClInclude Include="main\sdk\LayerMask.h" />
-    <ClInclude Include="main\sdk\LevelController.h" />
-    <ClInclude Include="main\sdk\LevelRoom.h" />
-    <ClInclude Include="main\sdk\LevelSelectionManager.h" />
-    <ClInclude Include="main\sdk\LevelStats.h" />
-    <ClInclude Include="main\sdk\LevelValues.h" />
-    <ClInclude Include="main\sdk\LiftButton.h" />
-    <ClInclude Include="main\sdk\Light.h" />
-    <ClInclude Include="main\sdk\LightningController.h" />
-    <ClInclude Include="main\sdk\LightSwitch.h" />
-    <ClInclude Include="main\sdk\LineRenderer.h" />
-    <ClInclude Include="main\sdk\LocalPCPlayer.h" />
-    <ClInclude Include="main\sdk\LocalPlayer.h" />
-    <ClInclude Include="main\sdk\Map.h" />
-    <ClInclude Include="main\sdk\MapController.h" />
-    <ClInclude Include="main\sdk\Material.h" />
-    <ClInclude Include="main\sdk\Media.h" />
-    <ClInclude Include="main\sdk\MethodInfo.h" />
-    <ClInclude Include="main\sdk\MonoBehaviour.h" />
-    <ClInclude Include="main\sdk\MouseLook.h" />
-    <ClInclude Include="main\sdk\Network.h" />
-    <ClInclude Include="main\sdk\Object.h" />
-    <ClInclude Include="main\sdk\ObjectiveManager.h" />
-    <ClInclude Include="main\sdk\PauseMenuController.h" />
-    <ClInclude Include="main\sdk\PhotonMessageInfo.h" />
-    <ClInclude Include="main\sdk\PhotonNetwork.h" />
-    <ClInclude Include="main\sdk\MediaValues.h" />
-    <ClInclude Include="main\sdk\PhotonObjectInteract.h" />
-    <ClInclude Include="main\sdk\PhotonView.h" />
-    <ClInclude Include="main\sdk\Physics.h" />
-    <ClInclude Include="main\sdk\PhysicsCharacterController.h" />
-    <ClInclude Include="main\sdk\Player.h" />
-    <ClInclude Include="main\sdk\PlayerSanity.h" />
-    <ClInclude Include="main\sdk\PlayerStamina.h" />
-    <ClInclude Include="main\sdk\Quaternion.h" />
-    <ClInclude Include="main\sdk\RandomWeather.h" />
-    <ClInclude Include="main\sdk\RaycastHit.h" />
-    <ClInclude Include="main\sdk\RectTransform.h" />
-    <ClInclude Include="main\sdk\Render.h" />
-    <ClInclude Include="main\sdk\RenderSettings.h" />
-    <ClInclude Include="main\sdk\Resources.h" />
-    <ClInclude Include="main\sdk\RewardManager.h" />
-    <ClInclude Include="main\sdk\Rigidbody.h" />
-    <ClInclude Include="main\sdk\SaltShaker.h" />
-    <ClInclude Include="main\sdk\SaltSpot.h" />
-    <ClInclude Include="main\sdk\SceneManagement.h" />
-    <ClInclude Include="main\sdk\SceneManager.h" />
-    <ClInclude Include="main\sdk\Screen.h" />
-    <ClInclude Include="main\sdk\ScriptableRenderContext.h" />
-    <ClInclude Include="main\sdk\sdk.h" />
-    <ClInclude Include="main\sdk\ServerManager.h" />
-    <ClInclude Include="main\sdk\Shader.h" />
-    <ClInclude Include="main\sdk\SteamFriends.h" />
-    <ClInclude Include="main\sdk\StoreItem.h" />
-    <ClInclude Include="main\sdk\StoreItemInfo.h" />
-    <ClInclude Include="main\sdk\String.h" />
-    <ClInclude Include="main\sdk\SummoningCircle.h" />
-    <ClInclude Include="main\sdk\System.h" />
-    <ClInclude Include="main\sdk\TarotCard.h" />
-    <ClInclude Include="main\sdk\TarotCards.h" />
-    <ClInclude Include="main\sdk\TextMeshProUGUI.h" />
-    <ClInclude Include="main\sdk\Texture.h" />
-    <ClInclude Include="main\sdk\Thermometer.h" />
-    <ClInclude Include="main\sdk\ThreeStateButton.h" />
-    <ClInclude Include="main\sdk\Time.h" />
-    <ClInclude Include="main\sdk\Torch.h" />
-    <ClInclude Include="main\sdk\Transform.h" />
-    <ClInclude Include="main\sdk\Vector2.h" />
-    <ClInclude Include="main\sdk\Vector3.h" />
-    <ClInclude Include="main\sdk\Voice.h" />
-    <ClInclude Include="main\sdk\VoodooDollPin.h" />
-    <ClInclude Include="main\sdk\WeatherProfile.h" />
-    <ClInclude Include="main\utils\notification.h" />
-    <ClInclude Include="main\utils\utils.h" />
-    <ClInclude Include="res\fonts\DefFont.hpp" />
-    <ClInclude Include="res\fonts\HeadFont.hpp" />
-    <ClInclude Include="res\fonts\MenuNewFont.h" />
-    <ClInclude Include="res\fonts\VCustomFont.hpp" />
-    <ClInclude Include="res\images\mic_off.h" />
-    <ClInclude Include="res\images\mic_on.h" />
-    <ClInclude Include="res\images\mirror.h" />
-    <ClInclude Include="res\images\monkey_paw.h" />
-    <ClInclude Include="res\images\music_box.h" />
-    <ClInclude Include="res\images\ouijaBoard.h" />
-    <ClInclude Include="res\images\summoningCircle.h" />
-    <ClInclude Include="res\images\tarotCard.h" />
-    <ClInclude Include="res\images\uv_default.h" />
-    <ClInclude Include="res\images\uv_obake.h" />
-    <ClInclude Include="res\images\voodooDoll.h" />
-    <ClInclude Include="main\features\feats\staminapanel\staminapanel.h" />
+    <ClCompile Include="dllmain.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="libs\il2cpp\il2cpp.cpp">
+      <Filter>Il2cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\hooking.cpp">
+      <Filter>hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\LevelController_Start.cpp">
+      <Filter>hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="main\logging\logger.cpp">
+      <Filter>logger</Filter>
+    </ClCompile>
+    <ClCompile Include="main\menu\menu.cpp">
+      <Filter>menu</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\WndProc.cpp">
+      <Filter>hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\Present.cpp">
+      <Filter>hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="main\menu\renderer.cpp">
+      <Filter>menu</Filter>
+    </ClCompile>
+    <ClCompile Include="main\utils\utils.cpp">
+      <Filter>utils</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\ExitLevel_Exit.cpp">
+      <Filter>hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feature.cpp">
+      <Filter>features</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\waterka\watermark.cpp">
+      <Filter>features\feats</Filter>
+    </ClCompile>
+    <ClCompile Include="main\config\configs_manager.cpp">
+      <Filter>configs</Filter>
+    </ClCompile>
+    <ClCompile Include="libs\imgui\imgui_draw.cpp">
+      <Filter>imgui</Filter>
+    </ClCompile>
+    <ClCompile Include="libs\imgui\imgui_impl_dx11.cpp">
+      <Filter>imgui</Filter>
+    </ClCompile>
+    <ClCompile Include="libs\imgui\imgui_impl_win32.cpp">
+      <Filter>imgui</Filter>
+    </ClCompile>
+    <ClCompile Include="libs\imgui\imgui_tables.cpp">
+      <Filter>imgui</Filter>
+    </ClCompile>
+    <ClCompile Include="libs\imgui\imgui_widgets.cpp">
+      <Filter>imgui</Filter>
+    </ClCompile>
+    <ClCompile Include="libs\imgui\imgui.cpp">
+      <Filter>imgui</Filter>
+    </ClCompile>
+    <ClCompile Include="libs\imgui\imgui_demo.cpp">
+      <Filter>imgui</Filter>
+    </ClCompile>
+    <ClCompile Include="main\config\config.cpp">
+      <Filter>configs</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\ghostpanel\ghostpanel.cpp">
+      <Filter>features\feats</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\MapController_Start.cpp">
+      <Filter>hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\GhostAI_Start.cpp">
+      <Filter>hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\GameController_Exit.cpp">
+      <Filter>hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\PauseMenuController_Leave.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\ghostesp\ghostesp.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\GhostAI_Hunting.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\fuseesp\fuseesp.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\GhostAI_Update.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\edvesp\edvesp.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\EvidenceController_Start.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\fullbright\fullbright.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\statspanel\statspanel.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\actmonik\actmonik.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\EMFData_Start.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\playerpanel\playerpanel.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\playeresp\playeresp.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\godmode\godmode.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\foveditor\foveditor.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\playermod\playermodifier.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\ghostmod\ghostmodifier.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\ghostinter\ghostinter.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\ghostdesign\ghostdesign.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\GhostInfo_SyncValuesNetworked.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\GhostInfo_SyncEvidence.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\pickup\pickup.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\PhotonObjectInteract_Start.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\mem\memory.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\custname\customname.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\FirstPersonController_Update.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\customlooklimits\customlooklimits.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\curseditemscontroll\curseditemscontroll.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\TarotCard_SetCard.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\infstamina\infinitystamina.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\noclip\noclip.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\PlayerStamina_Update.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\custspeed\customspeed.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\teleport\teleport.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\exitvanone\exitvanone.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\ExitLevel_ThereAreAlivePlayersOutsideTheTruck.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\antikick\antikick.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\ServerManager_KickPlayerNetworked.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\ObjectiveManager_Update.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\rewardmod\rewardmodifier.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\LevelValues_GetInvestigationBonusReward.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\LevelValues_IsPerfectGame.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\MediaValues_GetRewardAmount.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\diffmod\difficultymodifier.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\doormod\doormodifier.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\grabkey\grabkey.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\mapmod\mapmodifier.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\Key_Start.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\SaltShaker_Update.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\saltmod\saltmodifier.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\SaltSpot_SyncSalt.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\LevelSelectionManager_Start.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\tests\test.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\shopmod\shopmodifier.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\Application_CallLogCallback.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\forcestart\forcestart.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\ServerManager_Ready.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\notifyinfo\notifyinfo.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\DNAEvidence_GrabbedNetworked.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\FallTeleportBox_OnTriggerEnter.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\LightSwitch_Start.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\LightningController_Start.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\TarotCards_GrabCard.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\TarotCards_BreakItem.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\RandomWeather_Start.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\EMFData_UpdateNightMareGraph.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\CursedItemsController_Awake.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\LiftButton_AttemptUse.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\vanbuttonmod\vanbuttonmod.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\GameController_PlayerDied.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\config\LanguageManager.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\temperaturepanel\temperaturepanel.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\Thermometer_HoldUse.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\fastthermometer\fastthermometer.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\noendgame\noendgame.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\PhotonView_RPC.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\crosshairmod\crosshairmod.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\potatoeesp\potatoeesp.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\flashlightmod\flashlightmod.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\ServerManager_LoadScene.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\alwaysbloodmoon\alwaysbloodmoon.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\LiftButton_Update.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\DNAEvidence_Start.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\autopickupbone\autopickupbone.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\photomod\photomod.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\HandCamera_MoveNext.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="libs\z85\z85.c">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="libs\z85\z85_impl.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="libs\miniz\miniz.c">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\fontchanger\fontchanger.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\Player_Start.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\journalmod\journalmod.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\VoodooDollPin_Use.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="loader\entry.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="loader\proxy.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\diagnostics\diagnostics.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\jackalopeesp\jackalopeesp.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\Jackalope_Awake.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\EVPRecorder_CanAnswer.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\spiritboxalw\spiritboxalw.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\autogame\autogame.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\fusemod\fusemod.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\discordrpc\discordrpc.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\ScriptableRenderContext_Submit.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\Player_StartDeathAnimation.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\showmic\showmic.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\musicpanel\musicpanel.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\GameController_Awake.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\RewardManager_Awake.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\SceneManagement_Internal_SceneLoaded.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\CosmeticsUnlocker.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\cosmeticsunlocker\cosmeticunlocker.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\awesp\awesp.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\AWDoll_Awake.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\audiomod\audiomod.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\hooks\Key_GrabbedKey.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\skiplayeranim\skiplayeranim.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+    <ClCompile Include="main\features\feats\worldmodulation\worldmodulation.cpp">
+      <Filter>Исходные файлы</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Globals.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="inGame.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\detours\include\detver.h">
+      <Filter>detours</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\detours\include\syelog.h">
+      <Filter>detours</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\detours\include\detours.h">
+      <Filter>detours</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\sdk.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\il2cpp\il2cpp.h">
+      <Filter>Il2cpp</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\GhostAI.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\MethodInfo.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\MonoBehaviour.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Vector3.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Vector4.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Quaternion.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\String.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Vector2.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\GhostInfo.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\GhostModel.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\GhostTraits.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\GhostEvidence.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="Includes.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\hooks\Hooks.h">
+      <Filter>hooks</Filter>
+    </ClInclude>
+    <ClInclude Include="main\hooks\hooking.h">
+      <Filter>hooks</Filter>
+    </ClInclude>
+    <ClInclude Include="main\logging\logger.h">
+      <Filter>logger</Filter>
+    </ClInclude>
+    <ClInclude Include="main\menu\styles.h">
+      <Filter>menu</Filter>
+    </ClInclude>
+    <ClInclude Include="main\menu\menu.h">
+      <Filter>menu</Filter>
+    </ClInclude>
+    <ClInclude Include="main\menu\renderer.h">
+      <Filter>menu</Filter>
+    </ClInclude>
+    <ClInclude Include="main\utils\utils.h">
+      <Filter>utils</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\ExitLevel.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Cursor.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feature.h">
+      <Filter>features</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\settings.h">
+      <Filter>features</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\waterka\watermark.h">
+      <Filter>features\feats</Filter>
+    </ClInclude>
+    <ClInclude Include="main\config\configs_manager.h">
+      <Filter>configs</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\imgui\imgui_impl_dx11.h">
+      <Filter>imgui</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\imgui\imgui_impl_win32.h">
+      <Filter>imgui</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\imgui\imgui_internal.h">
+      <Filter>imgui</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\imgui\imstb_rectpack.h">
+      <Filter>imgui</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\imgui\imstb_textedit.h">
+      <Filter>imgui</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\imgui\imstb_truetype.h">
+      <Filter>imgui</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\imgui\imconfig.h">
+      <Filter>imgui</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\imgui\imgui.h">
+      <Filter>imgui</Filter>
+    </ClInclude>
+    <ClInclude Include="main\config\config.h">
+      <Filter>configs</Filter>
+    </ClInclude>
+    <ClInclude Include="res\fonts\DefFont.hpp">
+      <Filter>fonts</Filter>
+    </ClInclude>
+    <ClInclude Include="res\fonts\HeadFont.hpp">
+      <Filter>fonts</Filter>
+    </ClInclude>
+    <ClInclude Include="res\fonts\VCustomFont.hpp">
+      <Filter>fonts</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\ghostpanel\ghostpanel.h">
+      <Filter>features\feats</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Network.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Player.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\PlayerSanity.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\PlayerStamina.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\PhysicsCharacterController.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\GameObject.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LevelController.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LevelRoom.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LevelStats.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LevelValues.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\MapController.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Transform.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Camera.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Component.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\System.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\FuseBox.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\GameController.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Door.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\RaycastHit.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Rigidbody.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\PhotonNetwork.h">
+      <Filter>sdk</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\PauseMenuController.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\ghostesp\ghostesp.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\fuseesp\fuseesp.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\edvesp\edvesp.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Evidence.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\EvidenceController.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\MediaValues.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\fullbright\fullbright.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Light.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\statspanel\statspanel.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\actmonik\actmonik.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\EMFData.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LineRenderer.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\playerpanel\playerpanel.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\playeresp\playeresp.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\godmode\godmode.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\foveditor\foveditor.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\playermod\playermodifier.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\utils\notification.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\ghostmod\ghostmodifier.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\ghostinter\ghostinter.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\GhostActivity.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\ghostdesign\ghostdesign.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\PhotonObjectInteract.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\pickup\pickup.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\mem\memory.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\custname\customname.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\FirstPersonController.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\MouseLook.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\features_includes.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\360camera\camera360.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\customlooklimits\customlooklimits.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\curseditemscontroll\curseditemscontroll.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\CursedItemsController.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\CursedItem.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\TarotCards.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\TarotCard.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\infstamina\infinitystamina.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\noclip\noclip.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Time.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\custspeed\customspeed.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\teleport\teleport.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\exitvanone\exitvanone.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\ServerManager.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\antikick\antikick.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\ObjectiveManager.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\rewardmod\rewardmodifier.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Difficulty.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\diffmod\difficultymodifier.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\doormod\doormodifier.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Key.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\grabkey\grabkey.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Map.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\mapmod\mapmodifier.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\SceneManager.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LightSwitch.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Object.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\SaltShaker.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\saltmod\saltmodifier.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\SaltSpot.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\PhotonView.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LevelSelectionManager.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\tests\test.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\shopmod\shopmodifier.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\StoreItemInfo.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\ItemInfo.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\StoreItem.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Resources.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Application.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\JournalController.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\PhotonMessageInfo.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\TextMeshProUGUI.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\forcestart\forcestart.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\DNAEvidence.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\notifyinfo\notifyinfo.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\FallTeleportBox.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LightningController.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\RandomWeather.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\WeatherProfile.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Contract.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Animator.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LiftButton.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\vanbuttonmod\vanbuttonmod.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\config\LanguageManager.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\config\Translations.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="res\fonts\MenuNewFont.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\HandCamera.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Render.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LayerMask.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\temperaturepanel\temperaturepanel.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Thermometer.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\fastthermometer\fastthermometer.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\config\BindSystem.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\noendgame\noendgame.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Graphic.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Color.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\crosshairmod\crosshairmod.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\RectTransform.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Screen.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\potatoeesp\potatoeesp.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Torch.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\flashlightmod\flashlightmod.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Texture.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\alwaysbloodmoon\alwaysbloodmoon.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Collider.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\autopickupbone\autopickupbone.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\photomod\photomod.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Equipment.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\z85\z85.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\z85\z85.hpp">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="libs\miniz\miniz.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Font.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\fontchanger\fontchanger.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\GhostButton.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\journalmod\journalmod.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\ThreeStateButton.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Physics.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\SummoningCircle.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Candle.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\VoodooDollPin.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="loader\entry.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="loader\proxy.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\diagnostics\diagnostics.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Jackalope.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\jackalopeesp\jackalopeesp.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\EVPRecorder.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\spiritboxalw\spiritboxalw.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\autogame\autogame.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\fusemod\fusemod.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\menu\effects\rain.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\menu\effects\directx_blur.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\menu\effects\pshader.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\SteamFriends.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\discordrpc\discordrpc.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\ScriptableRenderContext.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LocalPCPlayer.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\LocalPlayer.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Journal_PhotoPage.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\JournalMedia.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Media.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="res\images\mic_off.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="res\images\mic_on.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\showmic\showmic.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Voice.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\musicpanel\musicpanel.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Button.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\RewardManager.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\SceneManagement.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="C:\Users\Xdsat\Downloads\Telegram Desktop\Translations_upd.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\CosmeticUnlocker.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\cosmeticsunlocker\cosmeticunlocker.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\AWDoll.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\awesp\awesp.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\AzureEffectsController.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\AudioSource.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\audiomod\audiomod.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\skiplayeranim\skiplayeranim.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\features\feats\worldmodulation\worldmodulation.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\RenderSettings.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Material.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
+    <ClInclude Include="main\sdk\Shader.h">
+      <Filter>Файлы заголовков</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/main/features/feats/fullbright/fullbright.cpp
+++ b/main/features/feats/fullbright/fullbright.cpp
@@ -1,13 +1,19 @@
 #include "fullbright.h"
 
-// Fullbright Implementation Improvement by BitterG
-
 using namespace PhasmoCheatV::Features::Visuals;
 
 Fullbright::Fullbright() : FeatureCore(LANG("Fullbright_Header"), TYPE_VISUALS)
 {
-    DECLARE_CONFIG(GetConfigManager(), "Intensity", float, 1.f);
-    DECLARE_CONFIG(GetConfigManager(), "Range", float, 30.f);
+    DECLARE_CONFIG(GetConfigManager(), "Intensity", float, 0.3f);
+    DECLARE_CONFIG(GetConfigManager(), "Range", float, 15.f);
+}
+
+static bool IsBleasdaleFarmhouse()
+{
+    auto* map = Utils::GetMap();
+    if (!map || !map->Fields.mapName) return false;
+    std::string name = Utils::UnityStrToSysStr(*map->Fields.mapName);
+    return name.find("Bleasdale") != std::string::npos;
 }
 
 void Fullbright::OnMenuRender()
@@ -33,26 +39,203 @@ void Fullbright::OnMenuRender()
             SET_CONFIG_VALUE(GetConfigManager(), "Range", float, range);
 
         if (ImGui::Button(LANG("ForceApply")))
+        {
+            BoostDarkMaterials();
             FullbrightMain();
+        }
     }
 
     ImGui::PopStyleVar();
 }
 
-void Fullbright::OnDeactivate() {
+static void SetShaderKeywords(bool disable)
+{
+    auto setKwd = [&](const char* kw) {
+        auto* str = Utils::SysStrToUnityStr(kw);
+        if (str) {
+            if (disable) SDK::Shader_DisableKeyword(str, nullptr);
+            else        SDK::Shader_EnableKeyword(str, nullptr);
+        }
+    };
+    setKwd("LIGHTMAP_ON");
+    setKwd("LIGHTMAP_SHADOW_MIXING");
+    setKwd("DIRLIGHTMAP_COMBINED");
+    setKwd("SHADOWS_SHADOWMASK");
+}
+
+// ============================================================
+// BoostPlayerLights — auto-runs every frame on Bleasdale
+// ============================================================
+
+void Fullbright::BoostPlayerLights()
+{
+    float intensity = CONFIG_FLOAT(GetConfigManager(), "Intensity");
+    float range = CONFIG_FLOAT(GetConfigManager(), "Range");
+
+    if (!InGame::firstPersonController) return;
+    auto* camera = InGame::firstPersonController->Fields.Camera;
+    if (!camera) return;
+
+    auto* camTransform = SDK::Component_Get_Transform((SDK::Component*)camera, nullptr);
+    if (!camTransform) return;
+    SDK::Vector3 camPos = SDK::Transform_Get_Position(camTransform, nullptr);
+
+    auto* lightType = Utils::GetType("UnityEngine.Light");
+    if (!lightType) return;
+
+    auto* arr = SDK::Object_FindObjectsOfType(lightType, nullptr);
+    if (!arr || arr->MaxLength == 0) return;
+
+    for (uint32_t i = 0; i < arr->MaxLength; i++) {
+        auto* lightObj = arr->Vector[i];
+        if (!lightObj) continue;
+
+        auto* lightGO = SDK::Component_Get_GameObject((SDK::Component*)lightObj, nullptr);
+        if (!lightGO) continue;
+
+        auto* lightTransform = SDK::GameObject_get_transform(lightGO, nullptr);
+        if (!lightTransform) continue;
+
+        SDK::Vector3 lightPos = SDK::Transform_Get_Position(lightTransform, nullptr);
+        float dx = lightPos.X - camPos.X;
+        float dy = lightPos.Y - camPos.Y;
+        float dz = lightPos.Z - camPos.Z;
+
+        if (dx * dx + dy * dy + dz * dz <= 25.0f) {
+            auto* light = (SDK::Light*)lightObj;
+            SDK::Light_intensity_set(light, intensity * 2.0f, nullptr);
+            SDK::Light_range_set(light, range * 1.5f, nullptr);
+            SDK::Light_shadows_set(light, SDK::ShadowsType::None, nullptr);
+            SDK::Light_renderMode_set(light, SDK::RenderMode::ForcePixel, nullptr);
+        }
+    }
+}
+
+// ============================================================
+// BoostDarkMaterials — manual via ForceApply button
+// ============================================================
+
+void Fullbright::BoostDarkMaterials()
+{
+    SetShaderKeywords(true);
+    SDK::RenderSettings_set_fog(false, nullptr);
+    SDK::Color white = { 1, 1, 1, 1 };
+    SDK::RenderSettings_set_ambientMode(0, nullptr);
+    SDK::RenderSettings_set_ambientIntensity(2.0f, nullptr);
+    SDK::RenderSettings_set_ambientLight(white, nullptr);
+    SDK::RenderSettings_set_ambientSkyColor(white, nullptr);
+    SDK::RenderSettings_set_ambientEquatorColor(white, nullptr);
+    SDK::RenderSettings_set_ambientGroundColor(white, nullptr);
+
+    auto* rendererType = Utils::GetType("UnityEngine.Renderer");
+    if (!rendererType) return;
+
+    auto* arr = SDK::Object_FindObjectsOfType(rendererType, nullptr);
+    if (!arr || arr->MaxLength == 0) return;
+
+    constexpr float kDarkThreshold = 0.15f;
+    constexpr float kTargetBrightness = 0.28f;
+    constexpr float kEmissionThreshold = 0.06f;
+
+    auto* baseColorStr = Utils::SysStrToUnityStr("_BaseColor");
+    auto* colorStr = Utils::SysStrToUnityStr("_Color");
+    auto* occStr = Utils::SysStrToUnityStr("_OcclusionStrength");
+    auto* emissionStr = Utils::SysStrToUnityStr("_EmissionColor");
+    auto* emissionKwStr = Utils::SysStrToUnityStr("_EMISSION");
+
+    if (!baseColorStr || !colorStr || !occStr || !emissionStr || !emissionKwStr) return;
+
+    auto* unlitShaderName = Utils::SysStrToUnityStr("Universal Render Pipeline/Unlit");
+    SDK::Shader* unlitShader = nullptr;
+    if (unlitShaderName)
+        unlitShader = SDK::Shader_Find(unlitShaderName, nullptr);
+
+    for (uint32_t i = 0; i < arr->MaxLength; i++)
+    {
+        auto* obj = arr->Vector[i];
+        if (!obj) continue;
+
+        auto* renderer = reinterpret_cast<SDK::Render*>(obj);
+        auto* mat = SDK::Render_get_sharedMaterial(renderer, nullptr);
+        if (!mat) continue;
+
+        SDK::Color baseColor = SDK::Material_GetColor(mat, baseColorStr, nullptr);
+        float brightness = baseColor.R * 0.2126f + baseColor.G * 0.7152f + baseColor.B * 0.0722f;
+
+        if (brightness <= 0.0f) {
+            baseColor = SDK::Material_get_color(mat, nullptr);
+            brightness = baseColor.R * 0.2126f + baseColor.G * 0.7152f + baseColor.B * 0.0722f;
+        }
+
+        if (brightness <= 0.0f || brightness >= kDarkThreshold)
+            continue;
+
+        if (brightness < kEmissionThreshold && unlitShader) {
+            SDK::Material_set_shader(mat, unlitShader, nullptr);
+            SDK::Color mildGrey = { 0.25f, 0.25f, 0.25f, 1.0f };
+            SDK::Material_set_color(mat, mildGrey, nullptr);
+            SDK::Material_SetColor(mat, baseColorStr, mildGrey, nullptr);
+        }
+        else {
+            float scale = kTargetBrightness / brightness;
+            SDK::Color boosted = {
+                (std::min)(baseColor.R * scale, 0.45f),
+                (std::min)(baseColor.G * scale, 0.45f),
+                (std::min)(baseColor.B * scale, 0.45f),
+                baseColor.A
+            };
+            SDK::Material_SetColor(mat, baseColorStr, boosted, nullptr);
+            SDK::Material_SetColor(mat, colorStr, boosted, nullptr);
+            SDK::Material_SetFloat(mat, occStr, 0.0f, nullptr);
+            SDK::Color lowEmission = { 0.06f, 0.06f, 0.06f, 1.0f };
+            SDK::Material_SetColor(mat, emissionStr, lowEmission, nullptr);
+            SDK::Material_EnableKeyword(mat, emissionKwStr, nullptr);
+        }
+
+        SDK::Render_set_lightmapIndex(renderer, 0xFFFF, nullptr);
+        SDK::Vector4 zeroOffset = { 0, 0, 0, 0 };
+        SDK::Render_set_lightmapScaleOffset(renderer, zeroOffset, nullptr);
+    }
+}
+
+// ============================================================
+// Core lifecycle
+// ============================================================
+
+void Fullbright::OnDeactivate()
+{
     if (InGame::FBGO) {
         SDK::Object_Destroy((SDK::Object*)InGame::FBGO, nullptr);
         InGame::FBGO = nullptr;
     }
+    else {
+        auto* fbName = Utils::SysStrToUnityStr("VComTeamLight");
+        if (fbName) {
+            auto* go = SDK::GameObject_Find(fbName, nullptr);
+            if (go) {
+                SDK::Object_Destroy((SDK::Object*)go, nullptr);
+            }
+        }
+    }
+
+    if (m_bleasdaleInitDone) {
+        SetShaderKeywords(false);
+        SDK::RenderSettings_set_fog(true, nullptr);
+        SDK::RenderSettings_set_ambientMode(1, nullptr);
+        SDK::RenderSettings_set_ambientIntensity(1.0f, nullptr);
+    }
+    m_bleasdaleInitDone = false;
 }
 
-void Fullbright::FullbrightMain() {
+void Fullbright::FullbrightMain()
+{
     SDK::String* fbName = Utils::SysStrToUnityStr("VComTeamLight");
     SDK::GameObject* gameObject = SDK::GameObject_Find(fbName, nullptr);
 
     if (!IsActive()) {
         if (gameObject) {
             SDK::Object_Destroy((SDK::Object*)gameObject, nullptr);
+            InGame::FBGO = nullptr;
         }
         return;
     }
@@ -78,6 +261,7 @@ void Fullbright::FullbrightMain() {
         SDK::Light_shadows_set(light, SDK::ShadowsType::None, nullptr);
         SDK::Light_renderMode_set(light, SDK::RenderMode::ForceVertex, nullptr);
         SDK::GameObject_SetActive(gameObject, true, nullptr);
+        InGame::FBGO = gameObject;
     }
     else {
         SDK::Light* light = reinterpret_cast<SDK::Light*>(
@@ -89,7 +273,7 @@ void Fullbright::FullbrightMain() {
                 ),
                 nullptr
             )
-            );
+        );
         if (light) {
             SDK::Light_intensity_set(light, intensity, nullptr);
             SDK::Light_range_set(light, range, nullptr);
@@ -110,7 +294,24 @@ void Fullbright::FullbrightMain() {
         SDK::Transform_Set_Parent(lightTransform, playerTransform, nullptr);
     }
     SDK::Vector3 playerPos = Utils::GetPosVec3(localPlayer);
-    playerPos.Y += 3.5f; // raise light above player head so floor is lit
+    playerPos.Y += 3.5f;
     SDK::Transform_Set_Position(lightTransform, playerPos, nullptr);
     SDK::Transform_Set_Rotation(lightTransform, SDK::identityQuaternion, nullptr);
+
+    // Bleasdale: auto-init lightmap/ambient fixes + per-frame player light boost
+    if (IsBleasdaleFarmhouse()) {
+        if (!m_bleasdaleInitDone) {
+            SetShaderKeywords(true);
+            SDK::RenderSettings_set_fog(false, nullptr);
+            SDK::Color white = { 1, 1, 1, 1 };
+            SDK::RenderSettings_set_ambientMode(0, nullptr);
+            SDK::RenderSettings_set_ambientIntensity(2.0f, nullptr);
+            SDK::RenderSettings_set_ambientLight(white, nullptr);
+            SDK::RenderSettings_set_ambientSkyColor(white, nullptr);
+            SDK::RenderSettings_set_ambientEquatorColor(white, nullptr);
+            SDK::RenderSettings_set_ambientGroundColor(white, nullptr);
+            m_bleasdaleInitDone = true;
+        }
+        BoostPlayerLights();
+    }
 }

--- a/main/features/feats/fullbright/fullbright.h
+++ b/main/features/feats/fullbright/fullbright.h
@@ -14,5 +14,10 @@ namespace PhasmoCheatV::Features::Visuals
 		void OnRender() override {}
 		void OnMenuRender() override;
 		void FullbrightMain();
+		void BoostDarkMaterials();
+		void BoostPlayerLights();
+
+	private:
+		bool m_bleasdaleInitDone = false;
 	};
 }

--- a/main/sdk/Material.h
+++ b/main/sdk/Material.h
@@ -7,6 +7,7 @@ namespace SDK
     struct Texture;
     DEC_MET(Material_set_color, void(*)(Material* material, Color value, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Material", "set_color", 1);
     DEC_MET(Material_SetColor, void(*)(Material* material, String* name, Color value, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Material", "SetColor", 2);
+    DEC_MET(Material_GetColor, Color(*)(Material* material, String* name, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Material", "GetColor", 1);
     DEC_MET(Material_SetFloat, void(*)(Material* material, String* name, float value, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Material", "SetFloat", 2);
     DEC_MET(Material_get_color, Color(*)(Material* material, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Material", "get_color", 0);
     DEC_MET(Material_set_mainTexture, void(*)(Material* material, Texture* value, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Material", "set_mainTexture", 1);

--- a/main/sdk/Render.h
+++ b/main/sdk/Render.h
@@ -11,4 +11,7 @@ namespace SDK
 	DEC_MET(Render_get_sharedMaterial, Material* (*)(Render* render, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Renderer", "get_sharedMaterial", 0);
 	DEC_MET(Render_set_material, void(*)(Render* render, Material* value, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Renderer", "set_material", 1);
 	DEC_MET(Render_set_sharedMaterial, void(*)(Render* render, Material* value, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Renderer", "set_sharedMaterial", 1);
+	DEC_MET(Render_get_lightmapIndex, int(*)(Render* render, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Renderer", "get_lightmapIndex", 0);
+	DEC_MET(Render_set_lightmapIndex, void(*)(Render* render, int value, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Renderer", "set_lightmapIndex", 1);
+	DEC_MET(Render_set_lightmapScaleOffset, void(*)(Render* render, Vector4 value, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Renderer", "set_lightmapScaleOffset", 1);
 }

--- a/main/sdk/Shader.h
+++ b/main/sdk/Shader.h
@@ -6,4 +6,6 @@ namespace SDK
 	struct Shader;
 
 	DEC_MET(Shader_Find, Shader* (*)(String* str, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Shader", "Find", 1);
+	DEC_MET(Shader_DisableKeyword, void(*)(String* keyword, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Shader", "DisableKeyword", 1);
+	DEC_MET(Shader_EnableKeyword, void(*)(String* keyword, MethodInfo* methodInfo), "UnityEngine.CoreModule", "UnityEngine", "Shader", "EnableKeyword", 1);
 }

--- a/main/sdk/Vector4.h
+++ b/main/sdk/Vector4.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace SDK
+{
+    struct Vector4
+    {
+        float X, Y, Z, W;
+    };
+}

--- a/main/sdk/sdk.h
+++ b/main/sdk/sdk.h
@@ -271,6 +271,7 @@ namespace SDK
 #include "Color.h"
 #include "Vector2.h"
 #include "Vector3.h"
+#include "Vector4.h"
 #include "Quaternion.h"
 #include "String.h"
 #include "MonoBehaviour.h"


### PR DESCRIPTION
## Summary

Fix dark furniture visibility on **Bleasdale Farmhouse** without affecting other maps.

## Problem

Some furniture models (cabinets, sofas, carpets) on Bleasdale Farmhouse stay nearly black even with Fullbright enabled. Neither increasing point light intensity/range nor modifying `Material.color` / `_BaseColor` fixes them.

## Root Cause

These models use custom shaders that don't respond to standard lighting or material property changes.

## Solution

Map-conditional logic — enhanced treatment only on Bleasdale, all other maps keep the original main-branch behavior.

### Auto (on Bleasdale, every frame)

| Operation | Detail |
|-----------|--------|
| Shader keywords | Disable `LIGHTMAP_ON` / `LIGHTMAP_SHADOW_MIXING` / `DIRLIGHTMAP_COMBINED` / `SHADOWS_SHADOWMASK` |
| RenderSettings | Ambient mode to flat, intensity ×2, all ambient colors to white, fog off |
| `BoostPlayerLights` | Scan all `Light` components within 5m of camera, boost `range ×1.5` + `intensity ×2` + shadows off + ForcePixel |

### Manual (ForceApply button)

| Operation | Detail |
|-----------|--------|
| Shader replacement | Replace dark material shaders with `Universal Render Pipeline/Unlit` |
| `_BaseColor` / `_Color` boost | Brighten materials below 0.15 brightness to 0.28 target |
| `_OcclusionStrength` | Set to 0 for all dark materials |
| Emission | `_EmissionColor = 0.06` + `_EMISSION` keyword |
| Lightmap clear | `lightmapIndex = 0xFFFF` + zero `lightmapScaleOffset` |

### Other Maps

No changes — identical to `main` branch (empty `OnActivate`, point light only, no scene traversal).

## Files Changed

| File | Change |
|------|--------|
| `fullbright.cpp` | +`BoostPlayerLights`, +`BoostDarkMaterials`, +`IsBleasdaleFarmhouse` |
| `fullbright.h` | New method declarations + `m_bleasdaleInitDone` flag |
| `sdk/Material.h` | +`Material_GetColor` binding |
| `sdk/Render.h` | +`lightmapIndex` / `lightmapScaleOffset` bindings |
| `sdk/Shader.h` | +`EnableKeyword` / `DisableKeyword` bindings |
| `sdk/Vector4.h` | New struct for `lightmapScaleOffset` |

## Testing

- Non-Bleasdale maps: no regression, identical to main
- Bleasdale: dark furniture visible automatically; ForceApply for full material fix
<img width="2560" height="1440" alt="Phasmophobia_gdDXY8Wb8D" src="https://github.com/user-attachments/assets/3733d145-f601-49de-98dc-7f543f11668b" />
<img width="2560" height="1440" alt="Phasmophobia_5YuF1OEUIw" src="https://github.com/user-attachments/assets/650a780e-a9f4-46d0-85fa-063f34ddb9fc" />
